### PR TITLE
add metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/madflojo/tasks v1.0.4 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
@@ -67,6 +68,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rs/xid v1.3.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.8.3 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/madflojo/tasks v1.0.4 h1:9pcztiBIw7BJYqStv+sckDNg+QO0/OHl7/0n6wfL0o8=
+github.com/madflojo/tasks v1.0.4/go.mod h1:8rVfjFGgxJ7aBxk4Ez/vHNKk5we9/DZDtzrBQbqsbkk=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -487,6 +489,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.3.0 h1:6NjYksEUlhurdVehpc7S7dk6DAmcKv8V9gG0FsVN2U4=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/helm/gk8soperator/templates/deployment.yaml
+++ b/helm/gk8soperator/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
           env:
           - name: GRAVITEE_OPERATOR_CONFIG_FILE
             value: /app/secrets/config.yaml
+          ports:
+          - name: metrics
+            containerPort: 8080
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/gk8soperator/values.yaml
+++ b/helm/gk8soperator/values.yaml
@@ -23,7 +23,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/port: "8080"
+  prometheus.io/scrape: "true"
+
 
 podSecurityContext:
   {}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3594,7 +3594,10 @@
         }],
         "responses": {
           "200": {
-            "description": "API analytics"
+            "description": "API analytics",
+            "schema": {
+              "type": "object"
+            }
           },
           "500": {
             "description": "Internal server error"


### PR DESCRIPTION
add metrics: response time API analytics are exposed via 8080/metrics 

API analytics exposed:
- `grevitee_api_endpoint_count`: count (api hits)
- `grevitee_api_endpoint_avg`: average response time
- `grevitee_api_endpoint_max`: max response time
- `grevitee_api_endpoint_min`: min response time